### PR TITLE
Corrected Integer Overflow decoding an encoded value of $FFFFFFFFFFFF…

### DIFF
--- a/src/sqids.pas
+++ b/src/sqids.pas
@@ -185,7 +185,7 @@ begin
   L := Length(AAlphabet);
 
   for C in AId do
-    Result := Result * L + TNumber(Pos(C, AAlphabet)) - 1;
+    Result := Result * L + (TNumber(Pos(C, AAlphabet)) - 1);
 end;
 
 function TSqids.IsBlocked(AId: string): Boolean;

--- a/tests/delphi/encoding.pas
+++ b/tests/delphi/encoding.pas
@@ -22,6 +22,7 @@ type
     procedure IdWithInvalidCharacter;
     // out-of-range test not implemented:
     // compiler enforces that all numbers are within the range of a TNumber
+    procedure ExtremeValue;
   end;
 
 implementation
@@ -175,6 +176,20 @@ begin
   with TSqids.Create do
   try
     CheckTrue(Decode('').Equals([]));
+  finally
+    Free;
+  end;
+end;
+
+procedure TTestEncoding.ExtremeValue;
+const
+  Number: TNumber = $FFFFFFFFFFFFFFFF;
+  Id = 'eIkvoXH40Lmd'; // from a previous EncodeSingle
+begin
+  with TSqids.Create do
+  try
+    CheckEquals(EncodeSingle(Number), Id);
+    CheckTrue(DecodeSingle(id)=Number);
   finally
     Free;
   end;


### PR DESCRIPTION
This corrects issue #2 where the value $FFFFFFFFFFFFFFFF encoded generates an integer overflow when decoding the value.  